### PR TITLE
fix: 修复局部变量未命中时的 null 合并回退逻辑，并补充测试

### DIFF
--- a/rollvm_syntax_uncovered_test.go
+++ b/rollvm_syntax_uncovered_test.go
@@ -28,6 +28,21 @@ func TestNullCoalescing(t *testing.T) {
 	}
 }
 
+func TestNullCoalescingWithGlobalFallback(t *testing.T) {
+	vm := NewVM()
+	vm.GlobalValueLoadOverwriteFunc = func(_ string, curVal *VMValue) *VMValue {
+		if curVal == nil {
+			return ni(0)
+		}
+		return curVal
+	}
+
+	err := vm.Run("a = null; a ?? 10")
+	if assert.NoError(t, err) {
+		assert.True(t, valueEqual(vm.Ret, ni(10)))
+	}
+}
+
 func TestExponentiation(t *testing.T) {
 	// ** 运算符
 	vm := NewVM()

--- a/types.go
+++ b/types.go
@@ -329,7 +329,7 @@ func (ctx *Context) LoadNameLocalWithDetail(name string, isRaw bool, detail *Buf
 	// if ctx.subThreadDepth >= 1 {
 	val, exists := ctx.Attrs.Load(name)
 	if !exists {
-		val = NewNullVal()
+		return nil
 	}
 
 	val = ctx.solveLoadPostAndComputed(name, val, isRaw, detail)
@@ -339,7 +339,11 @@ func (ctx *Context) LoadNameLocalWithDetail(name string, isRaw bool, detail *Buf
 }
 
 func (ctx *Context) LoadNameLocal(name string, isRaw bool) *VMValue {
-	return ctx.LoadNameLocalWithDetail(name, isRaw, nil)
+	ret := ctx.LoadNameLocalWithDetail(name, isRaw, nil)
+	if ret == nil {
+		return NewNullVal()
+	}
+	return ret
 }
 
 func (ctx *Context) LoadNameWithDetail(name string, isRaw bool, useHook bool, detail *BufferSpan) *VMValue {
@@ -363,7 +367,7 @@ func (ctx *Context) LoadNameWithDetail(name string, isRaw bool, useHook bool, de
 			ctx.Error = curCtx.Error
 			return nil
 		}
-		if ret.TypeId != VMTypeNull {
+		if ret != nil {
 			return ret
 		}
 		if curCtx.UpCtx == nil {


### PR DESCRIPTION
治这个毛病的：

<img width="1601" height="626" alt="图片" src="https://github.com/user-attachments/assets/ff2978e2-7bb2-4d08-8673-fe1b509dd09b" />

改后：

<img width="1586" height="618" alt="图片" src="https://github.com/user-attachments/assets/81c8d727-57d1-4db1-96d1-5128ef8143d3" />
