### PR TITLE
refactor(rand): 数据源产出封装，并支持纯随机数据源初始化

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ go run ./cmd ./script.ds
 
 启动时会先执行脚本，再进入 REPL。
 
+### 随机源
+
+DiceScript 默认使用 PCG 随机源。PCG 源支持保存和恢复当前随机状态，适合需要复现骰点序列、调试或续跑的场景：
+
+```go
+vm := dicescript.NewVM()
+seed, err := vm.GetCurSeed()
+
+vm2 := &dicescript.Context{Seed: seed}
+vm2.Init()
+```
+
+如果需要接入其他随机源，可以设置 `Context.RandSrc`。掷骰逻辑只要求随机源实现 `Uint64() uint64`：
+
+```go
+vm := dicescript.NewVM()
+vm.RandSrc = dicescript.NewCryptoDiceSource()
+```
+
+需要注意的是，真随机源不支持保存和恢复状态。此时调用 `GetCurSeed()` 会返回 `ErrDiceSourceStateUnsupported`。
 
 ## 设计原则
 

--- a/rand_source.go
+++ b/rand_source.go
@@ -1,0 +1,84 @@
+package dicescript
+
+import (
+	cryptorand "crypto/rand"
+	"encoding"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"time"
+
+	exprand "golang.org/x/exp/rand"
+)
+
+// DiceSource is the minimum capability required by dice rolling.
+type DiceSource interface {
+	Uint64() uint64
+}
+
+// StatefulDiceSource is a dice source whose current state can be saved and restored.
+type StatefulDiceSource interface {
+	DiceSource
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
+}
+
+var ErrDiceSourceStateUnsupported = errors.New("random source does not support binary state")
+
+var randSource = NewPCGDiceSource(uint64(time.Now().UnixMilli()))
+
+func NewPCGDiceSource(seed uint64) StatefulDiceSource {
+	src := &exprand.PCGSource{}
+	src.Seed(seed)
+	return src
+}
+
+func NewPCGDiceSourceFromState(state []byte) (StatefulDiceSource, error) {
+	src := &exprand.PCGSource{}
+	err := src.UnmarshalBinary(state)
+	return src, err
+}
+
+func NewCryptoDiceSource() DiceSource {
+	return &cryptoDiceSource{reader: cryptorand.Reader}
+}
+
+type cryptoDiceSource struct {
+	reader io.Reader
+}
+
+func (src *cryptoDiceSource) Uint64() uint64 {
+	reader := src.reader
+	if reader == nil {
+		reader = cryptorand.Reader
+	}
+
+	var data [8]byte
+	if _, err := io.ReadFull(reader, data[:]); err != nil {
+		panic(fmt.Errorf("crypto dice source failed: %w", err))
+	}
+	return binary.BigEndian.Uint64(data[:])
+}
+
+func normalizeDiceSource(src DiceSource) DiceSource {
+	if isNilDiceSource(src) {
+		return randSource
+	}
+	return src
+}
+
+func isNilDiceSource(src DiceSource) bool {
+	if src == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(src)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}

--- a/rand_source_test.go
+++ b/rand_source_test.go
@@ -1,0 +1,59 @@
+package dicescript
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type sequenceDiceSource struct {
+	values []uint64
+	index  int
+}
+
+func (s *sequenceDiceSource) Uint64() uint64 {
+	v := s.values[s.index%len(s.values)]
+	s.index++
+	return v
+}
+
+func TestRollAcceptsDiceSource(t *testing.T) {
+	src := &sequenceDiceSource{values: []uint64{4}}
+
+	ret := Roll(src, 6, 0)
+
+	assert.Equal(t, IntType(5), ret)
+}
+
+func TestGetCurSeedReportsUnsupportedForStatelessSource(t *testing.T) {
+	ctx := NewVM()
+	ctx.RandSrc = &sequenceDiceSource{values: []uint64{4}}
+
+	seed, err := ctx.GetCurSeed()
+
+	assert.Nil(t, seed)
+	assert.ErrorIs(t, err, ErrDiceSourceStateUnsupported)
+}
+
+func TestPCGDiceSourceStateRoundTrip(t *testing.T) {
+	src := NewPCGDiceSource(123)
+	_ = Roll(src, 100, 0)
+	seed, err := src.MarshalBinary()
+	assert.NoError(t, err)
+
+	restored, err := NewPCGDiceSourceFromState(seed)
+	assert.NoError(t, err)
+
+	assert.Equal(t, Roll(src, 100, 0), Roll(restored, 100, 0))
+}
+
+func TestCryptoDiceSourceUsesReaderAndIsStateless(t *testing.T) {
+	src := &cryptoDiceSource{reader: bytes.NewReader([]byte{0, 0, 0, 0, 0, 0, 0, 4})}
+
+	ret := Roll(src, 6, 0)
+	_, ok := any(src).(StatefulDiceSource)
+
+	assert.Equal(t, IntType(5), ret)
+	assert.False(t, ok)
+}

--- a/roll_func.go
+++ b/roll_func.go
@@ -7,20 +7,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
-
-	"golang.org/x/exp/rand"
 )
 
-func getSource() *rand.PCGSource {
-	s := &rand.PCGSource{}
-	s.Seed(uint64(time.Now().UnixMilli()))
-	return s
-}
-
-var randSource = getSource()
-
-func _roll32(src *rand.PCGSource, dicePoints int) int {
+func _roll32(src DiceSource, dicePoints int) int {
 	// 注: int的长度至少为32位，也可以高于此数，此处只是当作32位处理
 	if dicePoints > math.MaxInt32-1 {
 		return 0
@@ -41,7 +30,7 @@ func _roll32(src *rand.PCGSource, dicePoints int) int {
 	return int(v%n + 1)
 }
 
-func _roll64(src *rand.PCGSource, dicePoints int64, mod int) int64 {
+func _roll64(src DiceSource, dicePoints int64, mod int) int64 {
 	if dicePoints > math.MaxInt64-1 {
 		return 0
 	}
@@ -61,7 +50,7 @@ func _roll64(src *rand.PCGSource, dicePoints int64, mod int) int64 {
 	return int64(v%n + 1)
 }
 
-func Roll(src *rand.PCGSource, dicePoints IntType, mod int) IntType {
+func Roll(src DiceSource, dicePoints IntType, mod int) IntType {
 	if dicePoints == 0 {
 		return 0
 	}
@@ -71,9 +60,7 @@ func Roll(src *rand.PCGSource, dicePoints IntType, mod int) IntType {
 	if mod == 1 {
 		return dicePoints
 	}
-	if src == nil {
-		src = randSource
-	}
+	src = normalizeDiceSource(src)
 
 	// 大部分情况会走这个分支
 	if IntTypeSize == 8 {
@@ -112,7 +99,7 @@ func wodCheck(e *Context, addLine IntType, pool IntType, points IntType, thresho
 }
 
 // RollWoD 返回: 成功数，总骰数，轮数，细节
-func RollWoD(src *rand.PCGSource, addLine IntType, pool IntType, points IntType, threshold IntType, isGE bool, mode int) (IntType, IntType, IntType, string) {
+func RollWoD(src DiceSource, addLine IntType, pool IntType, points IntType, threshold IntType, isGE bool, mode int) (IntType, IntType, IntType, string) {
 	var details []string
 	addTimes := 1
 
@@ -211,7 +198,7 @@ func doubleCrossCheck(ctx *Context, addLine, pool, points IntType) bool {
 	return true
 }
 
-func RollDoubleCross(src *rand.PCGSource, addLine IntType, pool IntType, points IntType, mode int) (IntType, IntType, IntType, string) {
+func RollDoubleCross(src DiceSource, addLine IntType, pool IntType, points IntType, mode int) (IntType, IntType, IntType, string) {
 	var details []string
 	addTimes := 1
 
@@ -288,7 +275,7 @@ func RollDoubleCross(src *rand.PCGSource, addLine IntType, pool IntType, points 
 }
 
 // RollCommon (times)d(dicePoints)kl(lowNum) 或 (times)d(dicePoints)kh(highNum)
-func RollCommon(src *rand.PCGSource, times, dicePoints IntType, diceMin, diceMax *IntType, isKeepLH, lowNum, highNum IntType, mode int) (IntType, string) {
+func RollCommon(src DiceSource, times, dicePoints IntType, diceMin, diceMax *IntType, isKeepLH, lowNum, highNum IntType, mode int) (IntType, string) {
 	var nums []IntType
 	for i := IntType(0); i < times; i += 1 {
 		die := Roll(src, dicePoints, mode)
@@ -373,7 +360,7 @@ func RollCommon(src *rand.PCGSource, times, dicePoints IntType, diceMin, diceMax
 	return num, text
 }
 
-func RollCoC(src *rand.PCGSource, isBonus bool, diceNum IntType, mode int) (IntType, string) {
+func RollCoC(src DiceSource, isBonus bool, diceNum IntType, mode int) (IntType, string) {
 	diceResult := Roll(src, 100, mode)
 	diceTens := diceResult / 10
 	diceUnits := diceResult % 10
@@ -423,7 +410,7 @@ func RollCoC(src *rand.PCGSource, isBonus bool, diceNum IntType, mode int) (IntT
 	}
 }
 
-func RollFate(src *rand.PCGSource, mode int) (IntType, string) {
+func RollFate(src DiceSource, mode int) (IntType, string) {
 	detail := ""
 	sum := IntType(0)
 	for i := 0; i < 4; i++ {

--- a/types.go
+++ b/types.go
@@ -24,8 +24,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/rand"
 )
 
 type VMValueType int
@@ -172,8 +170,8 @@ type Context struct {
 	detailCache      string // 计算过程
 	IsComputedLoaded bool
 
-	Seed    []byte          // 随机种子，16个字节，即双uint64
-	RandSrc *rand.PCGSource // 根据种子生成的source
+	Seed    []byte     // PCG随机状态，16个字节，即双uint64
+	RandSrc DiceSource // 随机源
 
 	IsRunning      bool // 是否正在运行，Run时会置为true，halt时会置为false
 	CustomDiceInfo []*customDiceItem
@@ -224,17 +222,18 @@ func (ctx *Context) Init() {
 	ctx.DetailSpans = nil
 	ctx.CustomFlag = make(map[string]any)
 	if ctx.Seed != nil {
-		s := rand.PCGSource{}
-		_ = s.UnmarshalBinary(ctx.Seed)
-		ctx.RandSrc = &s
+		src, _ := NewPCGDiceSourceFromState(ctx.Seed)
+		ctx.RandSrc = src
 	}
 }
 
 func (ctx *Context) GetCurSeed() ([]byte, error) {
-	if ctx.RandSrc != nil {
-		return ctx.RandSrc.MarshalBinary()
+	src := normalizeDiceSource(ctx.RandSrc)
+	statefulSrc, ok := src.(StatefulDiceSource)
+	if !ok {
+		return nil, ErrDiceSourceStateUnsupported
 	}
-	return randSource.MarshalBinary()
+	return statefulSrc.MarshalBinary()
 }
 
 func (ctx *Context) loadInnerVar(name string) *VMValue {


### PR DESCRIPTION
为未来去海豹整神秘小活做准备。
### 随机源

DiceScript 默认使用 PCG 随机源。PCG 源支持保存和恢复当前随机状态，适合需要复现骰点序列、调试或续跑的场景：

```go
vm := dicescript.NewVM()
seed, err := vm.GetCurSeed()

vm2 := &dicescript.Context{Seed: seed}
vm2.Init()
```

如果需要接入其他随机源，可以设置 `Context.RandSrc`。掷骰逻辑只要求随机源实现 `Uint64() uint64`：

```go
vm := dicescript.NewVM()
vm.RandSrc = dicescript.NewCryptoDiceSource()
```

需要注意的是，真随机源不支持保存和恢复状态。此时调用 `GetCurSeed()` 会返回 `ErrDiceSourceStateUnsupported`。